### PR TITLE
feat: Implement dark mode with theme switcher

### DIFF
--- a/css/techfolio-theme/dark.css
+++ b/css/techfolio-theme/dark.css
@@ -1,0 +1,99 @@
+/* Dark theme overrides */
+body.dark-mode {
+  --bs-body-color: #e0e0e0; /* Lighter text for dark backgrounds */
+  --bs-body-bg: #121212;   /* Dark background for the body */
+  --bs-link-color: #bb86fc; /* A vibrant color for links, accessible on dark backgrounds */
+  --bs-link-hover-color: #d0b3ff;
+
+  /* Override Bootstrap global variables */
+  --bs-gray: #555555;
+  --bs-gray-100: #2a2a2a;
+  --bs-gray-200: #3c3c3c;
+  --bs-gray-300: #4f4f4f;
+  --bs-gray-400: #616161;
+  --bs-gray-500: #747474;
+  --bs-gray-600: #878787;
+  --bs-gray-700: #9a9a9a;
+  --bs-gray-800: #adadad;
+  --bs-gray-900: #c0c0c0;
+  --bs-white: #1e1e1e; /* Adjust white to a very dark gray or black for backgrounds */
+  --bs-black: #f0f0f0; /* Adjust black to a very light gray or white for text */
+
+  /* Techfolio specific variables */
+  --tf-pill-bg: var(--bs-gray-800); /* Darker pills */
+  --tf-icon-fill: var(--bs-gray-400); /* Icons need to be lighter */
+  --tf-page-bg-color: var(--bs-body-bg);
+  --tf-footer-bg-color: #1f1f1f; /* Slightly lighter than page bg for footer */
+  --tf-projects-bg-color: #272727; /* Slightly lighter than page bg for projects section */
+
+  /* Card specific overrides for dark mode */
+  --bs-card-bg: #222222;
+  --bs-card-border-color: #444444;
+  --bs-card-color: var(--bs-body-color);
+  --bs-card-cap-bg: #2a2a2a;
+  --bs-card-cap-color: var(--bs-body-color);
+  --bs-card-footer-bg: var(--bs-card-cap-bg); /* Ensure footer matches card styling */
+
+  /* Button overrides */
+  --bs-btn-color: var(--bs-black); /* Text color for buttons */
+  --bs-btn-bg: var(--bs-gray-700);
+  --bs-btn-border-color: var(--bs-gray-600);
+  --bs-btn-hover-bg: var(--bs-gray-600);
+  --bs-btn-hover-border-color: var(--bs-gray-500);
+  --bs-btn-active-bg: var(--bs-gray-500);
+  --bs-btn-active-border-color: var(--bs-gray-400);
+
+  --bs-btn-outline-color: var(--bs-gray-400); /* For outline buttons */
+  --bs-btn-outline-hover-color: var(--bs-body-bg);
+  --bs-btn-outline-hover-bg: var(--bs-gray-400);
+  --bs-btn-outline-active-bg: var(--bs-gray-500);
+
+
+  /* Navbar overrides */
+  --bs-navbar-color: rgba(240, 240, 240, 0.75); /* Lighter text for navbar */
+  --bs-navbar-hover-color: #f0f0f0;
+  --bs-navbar-disabled-color: rgba(240, 240, 240, 0.35);
+  --bs-navbar-active-color: #ffffff;
+  --bs-navbar-brand-color: var(--bs-navbar-active-color);
+  --bs-navbar-brand-hover-color: var(--bs-navbar-active-color);
+
+  /* Ensure header and footer specific styles are dark */
+  .bg-light { /* assuming .bg-light is used for header/footer */
+    background-color: var(--tf-footer-bg-color) !important; /* Important to override bootstrap utility */
+  }
+}
+
+/* Additional adjustments for specific elements if needed */
+body.dark-mode .card {
+  background-color: var(--bs-card-bg);
+  border-color: var(--bs-card-border-color);
+  color: var(--bs-card-color);
+}
+
+body.dark-mode .card-header, body.dark-mode .card-footer {
+  background-color: var(--bs-card-cap-bg);
+  color: var(--bs-card-cap-color);
+  border-top-color: var(--bs-card-border-color); /* Ensure border is also themed */
+}
+
+body.dark-mode .text-muted {
+  color: var(--bs-gray-600) !important;
+}
+
+body.dark-mode .navbar {
+  background-color: var(--tf-footer-bg-color) !important; /* Ensure navbar background is dark */
+}
+
+body.dark-mode .navbar-brand, body.dark-mode .nav-link {
+  color: var(--bs-navbar-color) !important;
+}
+
+body.dark-mode .navbar-brand:hover, body.dark-mode .nav-link:hover {
+  color: var(--bs-navbar-hover-color) !important;
+}
+
+/* Rouge syntax highlighting for dark mode */
+/* You might want to link to a specific dark Rouge theme here, 
+   or override its variables if it uses them.
+   For now, let's assume 'css/rouge/base16.dark.css' will be used
+   and linked separately in the HTML when dark mode is active. */

--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
     <link rel="shortcut icon" href="/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link rel="stylesheet" href="/css/techfolio-theme/default.css">
-    <link rel="stylesheet" type="text/css" href="/css/rouge/github.css">
+    <link id="rouge-style" rel="stylesheet" type="text/css" href="/css/rouge/github.css">
+    <link rel="stylesheet" href="/css/techfolio-theme/dark.css">
     <!-- Load MathJax if 'mathjax: true' is found in your _config.yml. -->
     
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-MML-AM_CHTML">
@@ -34,6 +35,7 @@
         <a class="nav-link" href="/#essays">Blog</a>
         <a class="nav-link" href="/resume.html">CV</a>
       </ul>
+      <button id="theme-switcher" class="btn btn-secondary btn-sm ms-2">Toggle Theme</button>
     </div>
   </div>
 </header>
@@ -341,5 +343,6 @@
 
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+  <script src="/js/theme-switcher.js"></script>
   </body>
 </html>

--- a/js/theme-switcher.js
+++ b/js/theme-switcher.js
@@ -1,0 +1,45 @@
+(function() {
+  const themeSwitcherButton = document.getElementById('theme-switcher');
+  if (!themeSwitcherButton) {
+    console.error('Theme switcher button not found');
+    return;
+  }
+  const rougeStyleLink = document.getElementById('rouge-style'); // New line
+
+  const THEME_KEY = 'theme-preference';
+  let currentTheme = localStorage.getItem(THEME_KEY);
+
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      document.body.classList.add('dark-mode');
+      themeSwitcherButton.textContent = 'Light Mode';
+      if (rougeStyleLink) { // New if block
+        rougeStyleLink.href = '/css/rouge/base16.dark.css';
+      }
+    } else {
+      document.body.classList.remove('dark-mode');
+      themeSwitcherButton.textContent = 'Dark Mode';
+      if (rougeStyleLink) { // New if block
+        rougeStyleLink.href = '/css/rouge/github.css';
+      }
+    }
+  }
+
+  if (currentTheme) {
+    applyTheme(currentTheme);
+  } else {
+    currentTheme = 'light'; // Defaulting to light
+    applyTheme(currentTheme);
+  }
+
+  themeSwitcherButton.addEventListener('click', function() {
+    if (document.body.classList.contains('dark-mode')) {
+      currentTheme = 'light';
+    } else {
+      currentTheme = 'dark';
+    }
+    localStorage.setItem(THEME_KEY, currentTheme);
+    applyTheme(currentTheme);
+  });
+
+})();


### PR DESCRIPTION
Adds a dark mode option to the website, toggleable via a button in the header.

Key changes:
- I created `css/techfolio-theme/dark.css` for dark theme styles.
- I added a theme switcher button to `index.html`.
- I implemented JavaScript in `js/theme-switcher.js` to:
    - Toggle a `dark-mode` class on the body.
    - Save theme preference in localStorage.
    - Apply saved theme on page load.
    - Switch Rouge syntax highlighting CSS (`github.css` for light, `base16.dark.css` for dark) based on the selected theme.
- I linked the new CSS and JS files in `index.html`.
- I added an ID to the Rouge CSS link in `index.html` to facilitate dynamic switching.